### PR TITLE
Small improvements

### DIFF
--- a/document.tex
+++ b/document.tex
@@ -1,4 +1,7 @@
 \documentclass[]{beamer}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
 
 %\setbeameroption{show notes}
 %\setbeameroption{hide notes}

--- a/document.tex
+++ b/document.tex
@@ -45,18 +45,18 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
  
  	\begin{frame}
  		\subsection{G20}
- 	\frametitle{Gipfelkunde | Herrschertreffen}
+ 	\frametitle{Gipfelkunde}  \framesubtitle{Herrschertreffen}
  	Solche Treffen in der Vormorderne werden als Herrschertreffen bezeichnet \dots
  	\note[item]{Das Herrschertreffen oder die Herrscherbegegnung ist ein Fachbegriff der Geschichtswissenschaft und bezeichnet persönliche Zusammentreffen von Monarchen als Mittel der Politik. Für die Treffen von Staats- und Regierungschefs hat sich im 20. Jahrhundert der Begriff Gipfeltreffen etabliert \cite{wiki:herrschertreffen}.}
 	 \end{frame}
  
  	\begin{frame}
-	\frametitle{Gipfelkunde | Name}
+	\frametitle{Gipfelkunde}  \framesubtitle{Name}
 	\dots aktuell steht \enquote{G20} für \enquote{Gruppe der zwanzig wichtigsten Industrie- und Schwellenländer}
 	\end{frame}
  
   	\begin{frame}
- 	\frametitle{Gipfelkunde | Fokus}
+ 	\frametitle{Gipfelkunde}  \framesubtitle{Fokus}
  	\begin{itemize}
  		\item Wirtschaft \& Finanzen
  		\item Klima \& Migration
@@ -79,7 +79,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	 \end{frame}
  
  	\begin{frame}
-	 	\frametitle{Gipfelkunde | Weltkarte}
+	 	\frametitle{Gipfelkunde}  \framesubtitle{Weltkarte}
 		\begin{figure}[h!]
 			\includegraphics[width=0.8\textwidth]{images/g20}
 			\caption{G20}
@@ -87,7 +87,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	 \end{frame}
 
 	\begin{frame}
-		\frametitle{Gipfelkunde | Eckdaten}
+		\frametitle{Gipfelkunde}  \framesubtitle{Eckdaten}
 		\begin{itemize}
 			\item dauert 2 bis 3 Tage
 			\item Abschlusserklärung
@@ -98,7 +98,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Fototermine und Fotos}
+	\frametitle{Gipfelkunde}  \framesubtitle{Fototermine und Fotos}
 	\begin{figure}[h!]
 		\renewcommand{\figurename}{Foto} 
 		\includegraphics[width=0.8\textwidth]{images/fotos_01_BundesregierungBergmann}
@@ -107,7 +107,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Fototermine und Fotos}
+	\frametitle{Gipfelkunde}  \framesubtitle{Fototermine und Fotos}
 	\begin{figure}[h!]
 		\renewcommand{\figurename}{Foto} 
 		\includegraphics[width=0.8\textwidth]{images/fotos_02_BundesregierungKugler}
@@ -116,7 +116,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Fototermine und Fotos}
+	\frametitle{Gipfelkunde}  \framesubtitle{Fototermine und Fotos}
 	\begin{figure}[h!]
 		\renewcommand{\figurename}{Foto} 
 		\includegraphics[width=0.8\textwidth]{images/fotos_03_BundesregierungKugler}
@@ -125,7 +125,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Fototermine und Fotos}	
+	\frametitle{Gipfelkunde}  \framesubtitle{Fototermine und Fotos}	
 	\begin{figure}[h!]
 		\renewcommand{\figurename}{Foto} 
 		\includegraphics[width=0.8\textwidth]{images/fotos_04_BundesregierungBergmann}
@@ -134,7 +134,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Fototermine und Fotos}
+	\frametitle{Gipfelkunde}  \framesubtitle{Fototermine und Fotos}
 	\begin{figure}[h!]
 		\renewcommand{\figurename}{Foto} 
 		\includegraphics[width=0.8\textwidth]{images/fotos_05_BundesregierungGuengoer}
@@ -143,7 +143,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Fototermine und Fotos}
+	\frametitle{Gipfelkunde}  \framesubtitle{Fototermine und Fotos}
 	\begin{figure}[h!]
 		\renewcommand{\figurename}{Foto} 
 		\includegraphics[width=0.8\textwidth]{images/fotos_06_BundesregierungKugler}
@@ -152,7 +152,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Fototermine und Fotos}
+	\frametitle{Gipfelkunde}  \framesubtitle{Fototermine und Fotos}
 	\begin{figure}[h!]
 		\renewcommand{\figurename}{Foto} 
 		\includegraphics[width=0.8\textwidth]{images/fotos_07_BundesregierungBergmann}
@@ -161,7 +161,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Fototermine und Fotos}
+	\frametitle{Gipfelkunde}  \framesubtitle{Fototermine und Fotos}
 	\begin{figure}[h!]
 		\renewcommand{\figurename}{Foto} 
 		\includegraphics[width=0.8\textwidth]{images/fotos_08_BundesregierungGuengoer}
@@ -170,7 +170,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Fototermine und Fotos}
+	\frametitle{Gipfelkunde}  \framesubtitle{Fototermine und Fotos}
 	\begin{figure}[h!]
 		\renewcommand{\figurename}{Foto} 
 		\includegraphics[width=0.8\textwidth]{images/fotos_09_BundesregierungKugler}
@@ -179,7 +179,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-		\frametitle{Gipfelkunde | Ergebnisse}
+		\frametitle{Gipfelkunde}  \framesubtitle{Ergebnisse}
 		Was hat der G20 jemals für uns getan?
 		\begin{figure}[h!]
 			\renewcommand{\figurename}{Foto} 
@@ -189,7 +189,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Ergebnisse}
+	\frametitle{Gipfelkunde}  \framesubtitle{Ergebnisse}
 	Was hat der G20 jemals für uns getan?
 	\begin{itemize}
 		\item Aquädukte?
@@ -211,13 +211,13 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Ergebnisse}
+	\frametitle{Gipfelkunde}  \framesubtitle{Ergebnisse}
 	Was hat der G20 jemals für uns getan?
 	\note[item]{Nichts hat der G20 getan. Es gibt kein verbindlichen Beschluss über gar nichts. Nicht einmal Visionen.}
 	\end{frame}
 
 	\begin{frame}
-		\frametitle{Gipfelkunde | Vergangene Gipfel}
+		\frametitle{Gipfelkunde}  \framesubtitle{Vergangene Gipfel}
 		\begin{itemize}
 			\item 2016 G20 in Hangzhou (VRC): 170.000 Personen werden überprüft, 255 Fabriken in Zwangsschließung, Deutschen Welle nicht akkreditiert)
 			\item 2008 G8 in Heiligendamm: Durchsuchungen vor dem Gipfeltreffen, 50.000 Gegendemonstranten allein auf der Auftaktdemonstration in Rostock, Bundeswehreinsatz, Satellitenaufklärung
@@ -236,13 +236,13 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Ergebnisse}
+	\frametitle{Gipfelkunde}  \framesubtitle{Ergebnisse}
 	Was hat der G20 jemals für uns getan?
 	\note[item]{Nichts hat der G20 getan. Es gibt kein verbindlichen Beschluss über gar nichts. Nicht einmal Visionen.}
 \end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Vergangene Gipfel: Lektion}
+	\frametitle{Gipfelkunde}  \framesubtitle{Vergangene Gipfel: Lektion}
 	\textbf{Vergangene Gipfel: Mögliche Lektionen}
 		\begin{itemize}
 			\item Deeskalation
@@ -253,7 +253,7 @@ https://cfp.mrmcd.net/2017/talk/ZZEFRH/}
 	\end{frame}
 
 	\begin{frame}
-	\frametitle{Gipfelkunde | Verwechslungsgefahr}
+	\frametitle{Gipfelkunde}  \framesubtitle{Verwechslungsgefahr}
 	\textbf{G20 (Schwellenländer)}
 	\begin{figure}[h!]
 %		\renewcommand{\figurename}{Foto} 


### PR DESCRIPTION
I added \framesubtitle and some packages. This improves umlaut handling, fonts and uses the Beamer templates better.

BTW.: The double entry in the table of contents is gone. :-)